### PR TITLE
Fix defer closing body after check for errors

### DIFF
--- a/download/download.go
+++ b/download/download.go
@@ -55,10 +55,10 @@ func GridAt(t *time.Time, depth, row, col int) (image.Image, error) {
 
 	// Get the image from the url.
 	res, err := http.Get(buf.String())
-	defer res.Body.Close()
 	if err != nil {
 		return nil, err
 	}
+	defer res.Body.Close()
 
 	// Create an image from the response.
 	img, _, err := image.Decode(res.Body)


### PR DESCRIPTION
For the GridAt function, you accidentally deferred the resp.Body.Close before you check for errors, when resp.Body would not be available if there is an error.
